### PR TITLE
set selenium jar to export = false in BuildConfig

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -32,6 +32,7 @@ grails.project.dependency.resolution = {
 
         test("org.seleniumhq.selenium:selenium-htmlunit-driver:2.3.1") {
             excludes "xercesImpl", "xmlParserAPIs", "xml-apis", "xerces", "commons-logging"
+            export = false
         }
 
         plugins {


### PR DESCRIPTION
Adding "export = false" for the selenium jar so it doesn't get loaded into host app's testing cycle and conflict with their selenium jars (which might differ).

See http://www.grails.org/doc/latest/guide/3.%20Configuration.html#3.7.7%20Plugin%20JAR%20Dependencies for details
