### PR TITLE
Update redis plugin to just released 1.1 version & remove runtime tomcat and hibernate

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -2,6 +2,4 @@
 #Fri Jul 15 14:25:27 CDT 2011
 app.grails.version=1.3.6
 app.name=jesque
-plugins.hibernate=1.3.6
 plugins.release=1.0.0.M2
-plugins.tomcat=1.3.6

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -36,7 +36,8 @@ grails.project.dependency.resolution = {
         }
     }
     plugins {
-        compile(':redis:1.0.0.M9')
+        compile(':redis:1.1')
         test(":spock:0.5-groovy-1.7")
+        test(":hibernate:1.3.6")
     }
 }


### PR DESCRIPTION
I've just released the redis 1.1 plugin with a bunch of additional functionality and some improvements to reduce the amount of time it ties up redis pool connection resources.  This pull request updates grails-jesque to the latest code.

I also made the hibernate plugin a test only dependency (so the integration tests can run) and removed tomcat as a dependency.
