### PR TITLE
Moving to Redis 1.2

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
-#Thu Feb 02 16:41:51 CST 2012
-app.grails.version=2.0.0
+#Fri Jul 15 14:25:27 CDT 2011
+app.grails.version=1.3.6
 app.name=jesque
 plugins.release=1.0.1

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -47,5 +47,3 @@ log4j = {
 
     warn   'org.mortbay.log'
 }
-grails.views.default.codec="none" // none, html, base64
-grails.views.gsp.encoding="UTF-8"

--- a/web-app/WEB-INF/applicationContext.xml
+++ b/web-app/WEB-INF/applicationContext.xml
@@ -6,28 +6,37 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 
 	<bean id="grailsApplication" class="org.codehaus.groovy.grails.commons.GrailsApplicationFactoryBean">
 		<description>Grails application factory bean</description>
-		<property name="grailsDescriptor" value="/WEB-INF/grails.xml" />
-		<property name="grailsResourceLoader" ref="grailsResourceLoader" />
+        <property name="grailsDescriptor" value="/WEB-INF/grails.xml" />
+        <property name="grailsResourceLoader" ref="grailsResourceLoader" />
 	</bean>
 
 	<bean id="pluginManager" class="org.codehaus.groovy.grails.plugins.GrailsPluginManagerFactoryBean">
 		<description>A bean that manages Grails plugins</description>
-		<property name="grailsDescriptor" value="/WEB-INF/grails.xml" />
-		<property name="application" ref="grailsApplication" />
+        <property name="grailsDescriptor" value="/WEB-INF/grails.xml" />
+        <property name="application" ref="grailsApplication" />
 	</bean>
 
-	<bean id="grailsConfigurator" class="org.codehaus.groovy.grails.commons.spring.GrailsRuntimeConfigurator">
-		<constructor-arg>
-			<ref bean="grailsApplication" />
-		</constructor-arg>
-		<property name="pluginManager" ref="pluginManager" />
-	</bean>
+    <bean id="grailsConfigurator" class="org.codehaus.groovy.grails.commons.spring.GrailsRuntimeConfigurator">
+        <constructor-arg>
+            <ref bean="grailsApplication" />
+        </constructor-arg>
+        <property name="pluginManager" ref="pluginManager" />
+    </bean>
 
-	<bean id="grailsResourceLoader" class="org.codehaus.groovy.grails.commons.GrailsResourceLoaderFactoryBean" />
+    <bean id="grailsResourceLoader" class="org.codehaus.groovy.grails.commons.GrailsResourceLoaderFactoryBean">
+        <property name="grailsResourceHolder" ref="grailsResourceHolder" />
+    </bean>
 
-	<bean id="characterEncodingFilter" class="org.springframework.web.filter.CharacterEncodingFilter">
-		<property name="encoding">
-			<value>utf-8</value>
-		</property>
-	</bean>
+    <bean id="grailsResourceHolder" scope="prototype" class="org.codehaus.groovy.grails.commons.spring.GrailsResourceHolder">
+        <property name="resources">
+              <value>classpath*:**/grails-app/**/*.groovy</value>
+        </property>
+    </bean>    
+    
+   <bean id="characterEncodingFilter"
+      class="org.springframework.web.filter.CharacterEncodingFilter">
+        <property name="encoding">
+          <value>utf-8</value>
+        </property>
+   </bean>    	
 </beans>

--- a/web-app/WEB-INF/sitemesh.xml
+++ b/web-app/WEB-INF/sitemesh.xml
@@ -5,7 +5,7 @@
         <parser content-type="text/html;charset=ISO-8859-1"
             class="org.codehaus.groovy.grails.web.sitemesh.GrailsHTMLPageParser" />
         <parser content-type="text/html;charset=UTF-8"
-            class="org.codehaus.groovy.grails.web.sitemesh.GrailsHTMLPageParser" />
+            class="org.codehaus.groovy.grails.web.sitemesh.GrailsHTMLPageParser" />            
     </page-parsers>
 
     <decorator-mappers>

--- a/web-app/WEB-INF/tld/c.tld
+++ b/web-app/WEB-INF/tld/c.tld
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<taglib xmlns="http://java.sun.com/xml/ns/javaee"
+<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
-    version="2.1">
-
-  <description>JSTL 1.2 core library</description>
+    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
+    version="2.0">
+    
+  <description>JSTL 1.1 core library</description>
   <display-name>JSTL core</display-name>
-  <tlib-version>1.2</tlib-version>
+  <tlib-version>1.1</tlib-version>
   <short-name>c</short-name>
   <uri>http://java.sun.com/jsp/jstl/core</uri>
 
@@ -74,7 +74,7 @@ not the body content should be processed.
         <description>
 Name of the exported scoped variable for the
 resulting value of the test condition. The type
-of the scoped variable is Boolean.
+of the scoped variable is Boolean.        
         </description>
         <name>var</name>
         <required>false</required>
@@ -174,9 +174,6 @@ Collection of items to iterate over.
 	<required>false</required>
 	<rtexprvalue>true</rtexprvalue>
 	<type>java.lang.Object</type>
-        <deferred-value>
-	    <type>java.lang.Object</type>
-        </deferred-value>
     </attribute>
     <attribute>
         <description>
@@ -256,9 +253,6 @@ String of tokens to iterate over.
 	<required>true</required>
 	<rtexprvalue>true</rtexprvalue>
 	<type>java.lang.String</type>
-        <deferred-value>
-	    <type>java.lang.String</type>
-        </deferred-value>
     </attribute>
     <attribute>
         <description>
@@ -328,7 +322,7 @@ visibility.
   <tag>
     <description>
         Like &lt;%= ... &gt;, but for expressions.
-    </description>
+    </description> 
     <name>out</name>
     <tag-class>org.apache.taglibs.standard.tag.rt.core.OutTag</tag-class>
     <body-content>JSP</body-content>
@@ -473,9 +467,6 @@ Expression to be evaluated.
         <name>value</name>
         <required>false</required>
         <rtexprvalue>true</rtexprvalue>
-        <deferred-value>
-	    <type>java.lang.Object</type>
-        </deferred-value>
     </attribute>
     <attribute>
         <description>

--- a/web-app/WEB-INF/tld/fmt.tld
+++ b/web-app/WEB-INF/tld/fmt.tld
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<taglib xmlns="http://java.sun.com/xml/ns/javaee"
+<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
-    version="2.1">
-
-  <description>JSTL 1.2 i18n-capable formatting library</description>
+    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
+    version="2.0">
+    
+  <description>JSTL 1.1 i18n-capable formatting library</description>
   <display-name>JSTL fmt</display-name>
-  <tlib-version>1.2</tlib-version>
+  <tlib-version>1.1</tlib-version>
   <short-name>fmt</short-name>
   <uri>http://java.sun.com/jsp/jstl/fmt</uri>
 
@@ -55,7 +55,7 @@ and may contain a two-letter (upper-case)
 country code (as defined by ISO-3166).
 Language and country codes must be
 separated by hyphen (-) or underscore
-(_).
+(_).        
 	</description>
         <name>value</name>
         <required>true</required>
@@ -496,7 +496,7 @@ Date and/or time to be formatted.
         <description>
 Specifies whether the time, the date, or both
 the time and date components of the given
-date are to be formatted.
+date are to be formatted. 
         </description>
         <name>type</name>
         <required>false</required>


### PR DESCRIPTION
Moving to Redis 1.2.  

Holding off on moving to Grails 2.0 for now even though this doesn't affect the grails run-time version of the plugin.  I think there is an unknown dependency to spock-1.5-groovy-1.7 that is important down stream. :)  Moving to Grails 2.0 for plugin would require new spock which uses new groovy 1.8 which could cause a conflict.  

Did you remove the spock dependency in your prod app yet?
