### PR TITLE
upgrading grails/jedis/grails-redis/jesque versions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ plugin.xml
 *.ipr
 *.zip
 stacktrace.log
+
+out/

--- a/JesqueGrailsPlugin.groovy
+++ b/JesqueGrailsPlugin.groovy
@@ -19,7 +19,7 @@ class JesqueGrailsPlugin {
 
     def version = "0.4.0-SNAPSHOT"
     def grailsVersion = "2.0.0 > *"
-    def dependsOn = [redis: "1.0.0M7 > *"]
+    def dependsOn = [redis: "1.3.1 > *"]
     def pluginExcludes = [
             "grails-app/views/**",
             "grails-app/domain/**",

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
 #Thu May 10 10:57:12 CDT 2012
-app.grails.version=2.0.1
+app.grails.version=2.0.3
 app.name=jesque

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -22,13 +22,12 @@ grails.project.dependency.resolution = {
         mavenRepo "http://repository.jboss.com/maven2/"
     }
     dependencies {
-        compile('net.greghaines:jesque:1.1.2',
-                'redis.clients:jedis:2.0.0',
-                'commons-pool:commons-pool:1.6',
-                'org.codehaus.jackson:jackson-mapper-asl:1.9.6',
-                'org.codehaus.jackson:jackson-core-asl:1.9.6') {
+        compile('commons-pool:commons-pool:1.6') {
             transitive = false
         }
+
+        compile('net.greghaines:jesque:1.2.0')
+        compile('redis.clients:jedis:2.1.0')
 
         compile('joda-time:joda-time:2.0')
 
@@ -38,11 +37,11 @@ grails.project.dependency.resolution = {
         }
     }
     plugins {
-        compile(':redis:1.0.0.M9')
+        compile(':redis:1.3.1')
         compile(':release:2.0.0', ':rest-client-builder:1.0.2') {
             export = false
         }
-        test(":spock:0.6-SNAPSHOT") {
+        test(":spock:0.6") {
             export = false
         }
         test(":hibernate:$grailsVersion") {

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -19,7 +19,7 @@ environments {
     }
     test {
         dataSource {
-            dbCreate = "update"
+            dbCreate = "create-drop"
             url = "jdbc:h2:mem:testDb"
         }
     }

--- a/grails-app/jobs/grails/plugin/jesque/test/DomainJob.groovy
+++ b/grails-app/jobs/grails/plugin/jesque/test/DomainJob.groovy
@@ -2,9 +2,8 @@ package grails.plugin.jesque.test
 
 class DomainJob {
 
-    void perform(id) {
-        def foo = Foo.get(id)
-        foo.name = foo.name + foo.name
-        foo.save()
+    void perform(name) {
+        Foo foo = new Foo(name: name)
+        foo.save(failOnError: true)
     }
 }

--- a/test/integration/grails/plugin/jesque/JesqueServiceIntegrationTests.groovy
+++ b/test/integration/grails/plugin/jesque/JesqueServiceIntegrationTests.groovy
@@ -42,25 +42,23 @@ class JesqueServiceIntegrationTests extends GrailsUnitTestCase {
     }
 
     void testWorkerDomainJob() {
-        def queueName = 'testQueue'
+        def queueName = 'domainJobTestQueue'
 
         def fooName = 'name'
-        def foo = new Foo(name:fooName)
-        foo.save(failOnError:true)
 
         def existingProcessedCount = queueInfoDao.processedCount
         def existingFailureCount = failureDao.count
 
-        jesqueService.enqueue(queueName, DomainJob.simpleName, foo.id )
+        jesqueService.enqueue(queueName, DomainJob.simpleName, fooName )
         jesqueService.withWorker(queueName, DomainJob.simpleName, DomainJob) {
             sleep(2000)
         }
 
-        foo.refresh()
+        assert Foo.count() == 1
 
-        assert existingProcessedCount + 1 == queueInfoDao.processedCount
         assert existingFailureCount == failureDao.count
-        assert fooName + fooName == foo.name
+        assert existingProcessedCount + 1 == queueInfoDao.processedCount
+        assert fooName == Foo.list().first().name
     }
 
     void testAutoWireJob() {


### PR DESCRIPTION
This pull request upgrades a number of components to more recent versions including:
- grails 2.0.1 -> grails 2.0.3 (didn't change plugin base requirement of > 2.0.0)
- grails-redis 1.0.0.M7 -> grails-redis 1.3.1
- spock-0.6-SNAPSHOT -> spock-0.6 
- jesque:1.1.2 -> jesque:1.2.0
- jedis:2.0.0 -> jedis:2.1.0

Many of the older versions are deprecated and some aren't available in maven central anymore making compilation difficult.

All tests pass with these changes.

I ran into problems with Grails 2 and the `JesqueServiceIntegrationTests.testWorkerDomainJob` test so I needed to change it a little bit.  The test created a `Foo` and then kicked off a job to modify that `Foo` and then checks to see if it's modified.  In grails 2, as far as I can tell, the test transactions have been changed a little so that there isn't any clean way for the test to commit it's work so that it's visibile to the job thread, so it was failing because the job test couldn't see the `Foo` to update it.  I changed it so that the job just creates a new `Foo` with a passed in name and the test asserts that it can see it after the job is done.  I think the spirit of the test is to ensure that hibernate/GORM works and this demonstrates that. 
