### PR TITLE
Add createWorkersOnStartup configuration setting 

### DIFF
--- a/JesqueGrailsPlugin.groovy
+++ b/JesqueGrailsPlugin.groovy
@@ -139,7 +139,10 @@ class JesqueGrailsPlugin {
         }
 
         jesqueConfigurationService.mergeClassConfigurationIntoConfigMap(jesqueConfigMap)
-        jesqueService.startWorkersFromConfig(jesqueConfigMap)
+        if(jesqueConfigMap.createWorkersOnStartup) {
+            log.info "Creating workers"
+            jesqueService.startWorkersFromConfig(jesqueConfigMap)
+        }
 
         applicationContext
     }

--- a/grails-app/conf/DefaultJesqueConfig.groovy
+++ b/grails-app/conf/DefaultJesqueConfig.groovy
@@ -1,6 +1,7 @@
 grails{
     jesque {
         pruneWorkersOnStartup = true
+        createWorkersOnStartup = true
         schedulerThreadActive = true
     }
 }


### PR DESCRIPTION
Allows worker creation to be controller at a global level. This is particularly useful in situations where you want web app servers to queue jobs but have no workers and non web-app servers running workers to process the queues
